### PR TITLE
Removed PUT log errors on Room / Fixed Next Button "one-off" bug / Join Room Alert

### DIFF
--- a/client/src/components/RoomButtons/index.js
+++ b/client/src/components/RoomButtons/index.js
@@ -59,7 +59,12 @@ class RoomButtons extends Component {
 					this.props.setJoinRoomAlert();
 				}, timeoutLength);
 			})
-			.catch(err => console.log(err));
+			.catch(err => {
+				if (err) {
+					this.setState({ inputAlertDisplay: true });
+					setTimeout(() => this.setState({ inputAlertDisplay: false }), 3000);
+				}
+			});
 	};
 
 	// Create Room button handler. Creates new Room in DB, then sets url.


### PR DESCRIPTION
Created handleNextTrack method, that will handle updating a track in our DB. This method verifies the track is associated with the room before attempting to update the DB. This method will be used in the handleNextClick and updatePlayedStatus methods. Tested to verify changes are working. Removes failed PUT error in console and "Track not associated with room" error in console.

Set a timeout to getCurrentlyPlaying inside of handleNextClick to fix "one-off" bug when clicking the next button. New track data will now take a moment to load but will be accurate of whats currently playing for the user.

Also made changes to syncQueueWithRoomAndJoin method in RoomButtons component. The catch will now display an error if the user attempts to join a room that does not exist.