### PR TITLE
Fixed Error: Cannot read property 'url' of undefined

### DIFF
--- a/client/src/pages/Room/index.js
+++ b/client/src/pages/Room/index.js
@@ -70,11 +70,11 @@ class Room extends Component {
 				// If user has undefined profile picture, use Playlistr logo instead
 				if (res.data.images[0] === undefined) {
 					let newImages = [];
-					let defaultImage = { url: './images/logo.jpg' };
+					let defaultImage = { url: './images/icons/playlistr-icon.png' };
 					newImages.push(defaultImage);
 					currentUser = {
 						...currentUser,
-						images: defaultImage
+						images: newImages
 					};
 				}
 


### PR DESCRIPTION
Fixed bug where the default image provided to user's without a Spotify Avatar is undefined. The default image was being set to the images property, instead of the array containing the default image.